### PR TITLE
sotry-deleted-modal Added axios call to delete modal. 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ function App() {
         <Routes>
           <Route path="/warehouse" element={<WarehouseListPage />} />
           <Route
-            path="/warehouse/:warehouseName/delete"
+            path="/warehouse/:warehouseName/:warehouseId/delete"
             element={<WarehouseListPage />}
           />
           <Route

--- a/src/components/DeleteWarehouseModal/DeleteWarehouseModal.jsx
+++ b/src/components/DeleteWarehouseModal/DeleteWarehouseModal.jsx
@@ -1,9 +1,21 @@
 import "./DeleteWarehouseModal.scss";
 import close from "../../assets/icons/close-24px.svg";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useParams } from "react-router-dom";
+import axios from "axios";
 
 function DeleteWarehouseModal({ Warehouse }) {
-  const warehouse = "Washington";
+  const base_url = import.meta.env.VITE_APP_BASE_URL;
+
+  const { warehouseName, warehouseId } = useParams();
+  const deleteWarehouse = async () => {
+    try {
+      await axios.delete(`${base_url}/stock/warehouses/${warehouseId}`);
+      alert(`${warehouseName} has been deleted`);
+      goBack();
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   const navigate = useNavigate();
 
@@ -37,7 +49,9 @@ function DeleteWarehouseModal({ Warehouse }) {
             </a>
             <Link
               className="delete-wml__button-2--wrapper"
-              onClick={() => goBack()}
+              onClick={() => {
+                deleteWarehouse();
+              }}
             >
               <button className="delete-wml__button-2">Delete</button>
             </Link>

--- a/src/components/WarehouseList/WarehouseList.jsx
+++ b/src/components/WarehouseList/WarehouseList.jsx
@@ -70,7 +70,7 @@ const WarehouseList = (viewDeleteModal) => {
             <div className="warehouse__alticons toggle-tabletdesktop">
               <Link
                 className="warehouse__link-delete"
-                to={`/warehouse/${warehouse.warehouse_name}/delete`}
+                to={`/warehouse/${warehouse.warehouse_name}/${warehouse.id}/delete`}
                 onClick={() => viewDeleteModal(warehouse.warehouse_name)}
               >
                 <img
@@ -124,7 +124,7 @@ const WarehouseList = (viewDeleteModal) => {
           <div className="warehouse__icons toggle-mobile">
             <Link
               className="warehouse__link-delete"
-              to={`/warehouse/${warehouse.warehouse_name}/delete`}
+              to={`/warehouse/${warehouse.warehouse_name}/${warehouse.id}/delete`}
               onClick={() => viewDeleteModal(warehouse.warehouse_name)}
             >
               <img src={deleteIcon} alt="delete" />


### PR DESCRIPTION
Added additional routing so that it returns to the previous page after an item is deleted.  

Also added an alert message, letting user know that the warehouse has been deleted.  

Warehouse list re-renders when returning to page, thereby refreshing the list without the deleted warehouse.